### PR TITLE
Issue #3: rename to ESP32-S3 Media Server + README/docs refresh + OTA web update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Release Entry Template (prepend newest entries directly below this template)
+## [vX.Y.Z] - YYYY-MM-DD
+### Added
+- ...
+### Changed
+- ...
+### Fixed
+- ...
+### Notes
+- PR: <url>
+- Issue: <url>
+
+## [v0.1.0] - 2026-03-14
+### Added
+- Initial ESP32-S3 Media Server firmware baseline with AP UI, SD browser, upload/download, and HTTP Range streaming.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,54 @@
-# ESP32-S3 Media Player (automation-first)
+# ESP32-S3 Media Server
 
-Goal: an ESP32-S3 device that serves files from microSD over a local Wi‑Fi AP and enables playback/viewing on a phone
-without accumulating storage on the phone (prefer streaming via HTTP Range requests).
+ESP32-S3 Media Server is firmware for `esp32-s3-devkitc-1-n32r16v` that:
+- starts a local Wi-Fi AP and serves a browser UI,
+- mounts and browses microSD media files,
+- supports upload/download + HTTP Range streaming for mobile players (VLC),
+- provides a web OTA firmware update flow with progress/status reporting.
 
-This repo is set up for **Pipeline A**:
-spec → issues → PRs → CI gates → (optional) auto-merge for low-risk changes.
+## Build and Upload (`esp32-s3-devkitc-1-n32r16v`)
+1. Install PlatformIO Core (CLI) and Python 3.
+2. Build:
+```bash
+pio run -e esp32-s3-devkitc-1-n32r16v
+```
+3. Upload firmware:
+```bash
+pio run -e esp32-s3-devkitc-1-n32r16v -t upload
+```
+4. Optional serial monitor:
+```bash
+pio device monitor -b 115200
+```
 
-## Quick start (repo bootstrap)
-1. Unzip the bootstrap bundle into the repo root.
-2. Commit and push.
-3. Create labels (script provided).
+## Wiring
+### DS3231 RTC (I2C)
+- RTC **GND** → Row 1 Right (GND)
+- RTC **VCC** → Row 21 Right (3V3)
+- RTC **SCL** → Row 8 Right (**IO9**)
+- RTC **SDA** → Row 11 Right (**IO8**)
+### MicroSD (SPI)
+- SD **GND** → Row 1 Right (GND)
+- SD **VCC** → Row 21 Right (3V3)
+- SD **CS** → Row 4 Right (**IO13**)
+- SD **SCK** → Row 5 Right (**IO12**)
+- SD **MISO** → Row 6 Right (**IO11**)
+- SD **MOSI** → Row 7 Right (**IO10**)
 
-See:
+## OTA Web Update
+- Open `http://192.168.4.1/ota`.
+- Upload a board-matching `firmware.bin`.
+- The page reports upload progress and OTA status.
+- On success, the device reports completion and reboots.
+- On interruption/error, OTA failure is reported and normal app flow continues.
+
+## Validation references
 - `ACCEPTANCE.md` for v0.1 binary checks
-- `.github/` for PR template, issue template, and CI gate
-- `docs/` for the automation policy
+- `docs/SMOKE_TEST_SPEC.md` for smoke verification details
 
-## Streaming approach
-Preferred: HTTP streaming with `Accept-Ranges: bytes` and correct `206 Partial Content` responses to Range requests.
-Most mobile players will only buffer small portions when Range is supported.
+## Changelog and releases
+- Update `CHANGELOG.md` in prepend order (newest entry first) for each merged PR.
+- Tag a release that matches the changelog update after merge.
 
 ## License
 MIT (see `LICENSE`).
-
-## Issue → PR automation
-See `docs/ISSUE_TO_PR_WORKFLOW.md` and `.github/workflows/codex-issue-to-pr.yml`.

--- a/docs/AUTOMATION_POLICY.md
+++ b/docs/AUTOMATION_POLICY.md
@@ -20,3 +20,7 @@ Automation MUST stop and ask for human input when:
 - breaking=yes
 - unknown hardware assumptions
 - flaky CI or non-deterministic test failures
+
+## Release hygiene (required after merge)
+- Every merged PR must update `CHANGELOG.md` (prepend order; newest entry first).
+- After merging, create and push a release tag that matches the changelog entry.

--- a/docs/ISSUE_3_IMPLEMENTATION_PLAN.md
+++ b/docs/ISSUE_3_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,33 @@
+# Issue #3 Implementation Plan
+
+Issue: https://github.com/i-schuyler/esp32-s3-media-player/issues/3
+
+## Scope
+- Rename user-facing software naming to **ESP32-S3 Media Server** in docs/UI where safe.
+- Add a web OTA update page and OTA POST flow with progress and clear status reporting.
+- Align SD SPI pin mapping with the required wiring documentation.
+- Add `CHANGELOG.md` with prepend-order release template.
+- Update docs/process so merged PRs must update changelog and create a release tag.
+
+## Mapping to ACCEPTANCE.md
+- `ACCEPTANCE.md` #7-10: preserve existing HTTP range streaming behavior (`Accept-Ranges`, `206`, `Content-Range`, `no-store`).
+- `ACCEPTANCE.md` #13: keep CI green and policy-gate compatible PR metadata.
+
+Issue-specific acceptance beyond `ACCEPTANCE.md`:
+- OTA web update UI + upload flow with progress/status and graceful failure handling.
+- Wiring block is included verbatim in README, and SD code pinning matches docs.
+- Changelog template + release hygiene process docs are added.
+
+## Mapping to docs/SMOKE_TEST_SPEC.md
+- Preserve boot markers (`BOOT: OK`, `WIFI AP STARTED`, `ESP32-MEDIA: READY`) for smoke regex compatibility.
+- Preserve SD mount/read/list markers.
+- Preserve streaming smoke behavior and logs for Range requests.
+- Add OTA manual verification notes aligned with the issue test plan and existing smoke process.
+
+## Verification Plan
+- Run `./ci.sh` (policy files present + PlatformIO compile for `esp32-s3-devkitc-1-n32r16v`).
+- Manual OTA check:
+  - Open `/ota`, upload valid `firmware.bin`, observe progress + success message + reboot.
+  - Interrupt upload/network to verify clear failure status and continued app availability.
+- Manual stream check:
+  - `Range: bytes=0-1023` => `206` + `Content-Range`; VLC Android playback remains functional.

--- a/docs/ISSUE_TO_PR_WORKFLOW.md
+++ b/docs/ISSUE_TO_PR_WORKFLOW.md
@@ -31,6 +31,7 @@ gh secret set OPENAI_API_KEY
 
 ## Notes
 - If you later prefer OAuth/Codex subscription instead of an API key, we can adjust the workflow.
+- After each merged PR, prepend the corresponding entry in `CHANGELOG.md` and create a matching release tag.
 
 ## Notification
 On success, the workflow comments on the originating issue with `PR created: <link>`.

--- a/docs/SMOKE_TEST_SPEC.md
+++ b/docs/SMOKE_TEST_SPEC.md
@@ -53,3 +53,11 @@ Manual verification (phone VLC or curl from laptop):
 
 ## Optional: play 2s clip (future local playback)
 This is a placeholder until we add local audio-out. For now, streaming playback on phone is the test.
+
+## OTA web update (manual)
+Manual verification:
+- Open `http://192.168.4.1/ota`.
+- Upload a valid `firmware.bin` for `esp32-s3-devkitc-1-n32r16v`.
+- Expect browser upload progress updates and clear status text.
+- Success path: status indicates success and device reboots.
+- Failure path (interrupt upload/network): status indicates failure/aborted and app remains reachable after retry.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,15 +2,32 @@
 #include <FS.h>
 #include <SD.h>
 #include <SPI.h>
+#include <Update.h>
 #include <WebServer.h>
 #include <WiFi.h>
 
 namespace {
 WebServer server(80);
 
-constexpr uint8_t kSdCsPin = 10;
+constexpr uint8_t kSdCsPin = 13;
+constexpr uint8_t kSdSckPin = 12;
+constexpr uint8_t kSdMisoPin = 11;
+constexpr uint8_t kSdMosiPin = 10;
 constexpr const char* kDefaultApPassword = "12345678";
 constexpr size_t kChunkSize = 2048;
+
+struct OtaStatus {
+  bool inProgress = false;
+  bool success = false;
+  bool hasResult = false;
+  size_t received = 0;
+  size_t expected = 0;
+  String message = F("idle");
+};
+
+OtaStatus gOtaStatus;
+bool gOtaRestartPending = false;
+unsigned long gOtaRestartAtMs = 0;
 
 String htmlEscape(const String& in) {
   String out;
@@ -21,6 +38,20 @@ String htmlEscape(const String& in) {
     else if (c == '<') out += F("&lt;");
     else if (c == '>') out += F("&gt;");
     else if (c == '"') out += F("&quot;");
+    else out += c;
+  }
+  return out;
+}
+
+String jsonEscape(const String& in) {
+  String out;
+  out.reserve(in.length() + 8);
+  for (size_t i = 0; i < in.length(); ++i) {
+    const char c = in.charAt(i);
+    if (c == '"') out += F("\\\"");
+    else if (c == '\\') out += F("\\\\");
+    else if (c == '\n') out += F("\\n");
+    else if (c == '\r') out += F("\\r");
     else out += c;
   }
   return out;
@@ -48,9 +79,10 @@ void handleRoot() {
   String body;
   body.reserve(512);
   body += F("<!doctype html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>");
-  body += F("<title>ESP32 Media</title></head><body>");
-  body += F("<h1>ESP32 Media</h1>");
+  body += F("<title>ESP32-S3 Media Server</title></head><body>");
+  body += F("<h1>ESP32-S3 Media Server</h1>");
   body += F("<p><a href='/files'>Open file browser</a></p>");
+  body += F("<p><a href='/ota'>Firmware update (OTA)</a></p>");
   body += F("</body></html>");
   server.send(200, F("text/html"), body);
 }
@@ -91,6 +123,7 @@ void handleFilesPage() {
   body.reserve(4096);
   body += F("<!doctype html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>");
   body += F("<title>ESP32 Files</title></head><body><h1>SD Browser</h1>");
+  body += F("<p><a href='/ota'>Open OTA firmware updater</a></p>");
   body += F("<form method='POST' action='/upload' enctype='multipart/form-data'>");
   body += F("<input type='file' name='file'/>");
   body += F("<button type='submit'>Upload</button></form>");
@@ -126,6 +159,45 @@ void handleListApi() {
 
   Serial.println(F("SD: LIST OK"));
   server.send(200, F("application/json"), json);
+}
+
+void handleOtaStatusApi() {
+  String json = "{";
+  json += "\"in_progress\":";
+  json += gOtaStatus.inProgress ? "true" : "false";
+  json += ",\"success\":";
+  json += gOtaStatus.success ? "true" : "false";
+  json += ",\"has_result\":";
+  json += gOtaStatus.hasResult ? "true" : "false";
+  json += ",\"received\":";
+  json += String(static_cast<unsigned long>(gOtaStatus.received));
+  json += ",\"expected\":";
+  json += String(static_cast<unsigned long>(gOtaStatus.expected));
+  json += ",\"message\":\"";
+  json += jsonEscape(gOtaStatus.message);
+  json += "\"}";
+  server.send(200, F("application/json"), json);
+}
+
+void handleOtaPage() {
+  String body;
+  body.reserve(2600);
+  body += F("<!doctype html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>");
+  body += F("<title>OTA Update</title></head><body>");
+  body += F("<h1>OTA Firmware Update</h1>");
+  body += F("<p>Upload a valid firmware.bin built for this board.</p>");
+  body += F("<form id='otaForm' method='POST' action='/ota' enctype='multipart/form-data'>");
+  body += F("<input id='fw' type='file' name='firmware' accept='.bin,application/octet-stream' required/>");
+  body += F("<button type='submit'>Start OTA</button></form>");
+  body += F("<p id='uploadProgress'>Upload progress: 0%</p>");
+  body += F("<p id='status'>Status: idle</p>");
+  body += F("<p><a href='/'>Back</a></p>");
+  body += F("<script>");
+  body += F("const f=document.getElementById('otaForm');const p=document.getElementById('uploadProgress');const s=document.getElementById('status');");
+  body += F("f.addEventListener('submit',function(e){e.preventDefault();const file=document.getElementById('fw').files[0];if(!file){s.textContent='Status: select firmware.bin first';return;}const data=new FormData();data.append('firmware',file);const x=new XMLHttpRequest();x.open('POST','/ota',true);x.upload.onprogress=function(ev){if(ev.lengthComputable){const pct=Math.round((ev.loaded/ev.total)*100);p.textContent='Upload progress: '+pct+'%';s.textContent='Status: uploading...';}};x.onreadystatechange=function(){if(x.readyState===4){s.textContent='Status: '+x.responseText;}};x.onerror=function(){s.textContent='Status: upload failed (network error)';};x.send(data);});");
+  body += F("setInterval(function(){fetch('/api/ota/status').then(r=>r.json()).then(j=>{let msg='Status: '+j.message;if(j.in_progress){msg+=' ('+j.received+' bytes)';}s.textContent=msg;}).catch(()=>{});},1000);");
+  body += F("</script></body></html>");
+  server.send(200, F("text/html"), body);
 }
 
 void handleDownload() {
@@ -231,6 +303,74 @@ void handleUploadDone() {
   server.send(200, F("text/plain"), F("upload complete"));
 }
 
+void handleOtaDone() {
+  if (gOtaStatus.success) {
+    server.send(200, F("text/plain"), gOtaStatus.message);
+  } else {
+    server.send(500, F("text/plain"), gOtaStatus.message);
+  }
+}
+
+void handleOtaChunk() {
+  HTTPUpload& upload = server.upload();
+  if (upload.status == UPLOAD_FILE_START) {
+    gOtaStatus.inProgress = true;
+    gOtaStatus.success = false;
+    gOtaStatus.hasResult = false;
+    gOtaStatus.received = 0;
+    gOtaStatus.expected = static_cast<size_t>(upload.totalSize);
+    gOtaStatus.message = F("starting OTA update");
+    gOtaRestartPending = false;
+    if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
+      gOtaStatus.inProgress = false;
+      gOtaStatus.hasResult = true;
+      gOtaStatus.message = F("OTA failed: unable to start update");
+      Serial.println(F("OTA: BEGIN FAILED"));
+    }
+  } else if (upload.status == UPLOAD_FILE_WRITE) {
+    if (!gOtaStatus.inProgress) return;
+    const size_t written = Update.write(upload.buf, upload.currentSize);
+    if (written != upload.currentSize) {
+      Update.abort();
+      gOtaStatus.inProgress = false;
+      gOtaStatus.hasResult = true;
+      gOtaStatus.message = F("OTA failed: write error");
+      Serial.println(F("OTA: WRITE FAILED"));
+      return;
+    }
+    gOtaStatus.received += upload.currentSize;
+    if (gOtaStatus.expected > 0) {
+      const unsigned long pct = static_cast<unsigned long>((gOtaStatus.received * 100UL) / gOtaStatus.expected);
+      gOtaStatus.message = "uploading firmware (" + String(pct) + "%)";
+    } else {
+      gOtaStatus.message = F("uploading firmware");
+    }
+  } else if (upload.status == UPLOAD_FILE_END) {
+    if (!gOtaStatus.inProgress) return;
+    if (Update.end(true)) {
+      gOtaStatus.inProgress = false;
+      gOtaStatus.success = true;
+      gOtaStatus.hasResult = true;
+      gOtaStatus.message = F("OTA successful. Device will reboot.");
+      gOtaRestartPending = true;
+      gOtaRestartAtMs = millis() + 1500;
+      Serial.println(F("OTA: SUCCESS"));
+    } else {
+      gOtaStatus.inProgress = false;
+      gOtaStatus.hasResult = true;
+      gOtaStatus.message = String(F("OTA failed: ")) + Update.errorString();
+      Serial.println(F("OTA: END FAILED"));
+    }
+  } else if (upload.status == UPLOAD_FILE_ABORTED) {
+    Update.abort();
+    gOtaStatus.inProgress = false;
+    gOtaStatus.success = false;
+    gOtaStatus.hasResult = true;
+    gOtaStatus.message = F("OTA failed: upload interrupted or aborted");
+    Serial.println(F("OTA: ABORTED"));
+  }
+}
+
 void handleUploadChunk() {
   HTTPUpload& upload = server.upload();
   static File uploadFile;
@@ -263,13 +403,17 @@ void configureRoutes() {
   server.on("/", HTTP_GET, handleRoot);
   server.on("/files", HTTP_GET, handleFilesPage);
   server.on("/api/list", HTTP_GET, handleListApi);
+  server.on("/api/ota/status", HTTP_GET, handleOtaStatusApi);
   server.on("/download", HTTP_GET, handleDownload);
   server.on("/stream", HTTP_GET, handleStream);
   server.on("/upload", HTTP_POST, handleUploadDone, handleUploadChunk);
+  server.on("/ota", HTTP_GET, handleOtaPage);
+  server.on("/ota", HTTP_POST, handleOtaDone, handleOtaChunk);
   server.onNotFound([]() { server.send(404, F("text/plain"), F("not found")); });
 }
 
 bool mountSd() {
+  SPI.begin(kSdSckPin, kSdMisoPin, kSdMosiPin, kSdCsPin);
   if (!SD.begin(kSdCsPin)) {
     Serial.println(F("SD: MOUNT FAILED"));
     return false;
@@ -311,5 +455,8 @@ void setup() {
 }
 
 void loop() {
+  if (gOtaRestartPending && static_cast<long>(millis() - gOtaRestartAtMs) >= 0) {
+    ESP.restart();
+  }
   server.handleClient();
 }


### PR DESCRIPTION
## Linked Issue
Fixes: https://github.com/i-schuyler/esp32-s3-media-player/issues/3

## Scope
- Rename user-facing docs/project references to ESP32-S3 Media Server where appropriate
- Refresh README to describe the software and add build/upload instructions
- Add wiring documentation and align documented pins as needed
- Add OTA web update flow with upload progress and graceful failure reporting
- Add CHANGELOG.md template and prepend-order release entries/process notes

RISK: high
BREAKING: no
NEEDS_HIL: no
