### PR TITLE
Issue #11: automate post-merge tag, release, and firmware asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout merged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Determine release version from CHANGELOG
+        id: version
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${{ github.event.pull_request.merge_commit_sha }}" ]]; then
+            echo "::error::Missing pull_request.merge_commit_sha; cannot determine release commit."
+            exit 1
+          fi
+
+          version_line="$(grep -E '^## \[v[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' CHANGELOG.md | head -n1 || true)"
+          if [[ -z "$version_line" ]]; then
+            echo "::error::No usable changelog release entry found. Expected top entries like: ## [v0.1.2] - 2026-03-16"
+            exit 1
+          fi
+
+          version="$(echo "$version_line" | sed -E 's/^## \[(v[0-9]+\.[0-9]+\.[0-9]+)\] - .*/\1/')"
+          if [[ -z "$version" ]]; then
+            echo "::error::Failed to parse version from CHANGELOG line: $version_line"
+            exit 1
+          fi
+
+          if git show-ref --verify --quiet "refs/tags/${version}"; then
+            echo "::error::Tag ${version} already exists. Update CHANGELOG.md with a new unreleased version before merge."
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version_line=${version_line}" >> "$GITHUB_OUTPUT"
+
+      - name: Build firmware for esp32-s3-devkitc-1-n32r16v
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --upgrade pip
+          python3 -m pip install --quiet platformio
+          pio run -e esp32-s3-devkitc-1-n32r16v
+
+      - name: Validate firmware artifact
+        id: firmware
+        run: |
+          set -euo pipefail
+
+          expected_path=".pio/build/esp32-s3-devkitc-1-n32r16v/firmware.bin"
+          mapfile -t firmware_bins < <(find .pio/build -type f -name firmware.bin | sort)
+
+          if (( ${#firmware_bins[@]} == 0 )); then
+            echo "::error::No firmware.bin artifact found under .pio/build after build."
+            exit 1
+          fi
+
+          if (( ${#firmware_bins[@]} > 1 )); then
+            echo "::error::Ambiguous firmware artifacts detected. Expected exactly one firmware.bin, found ${#firmware_bins[@]}:"
+            printf ' - %s\n' "${firmware_bins[@]}"
+            exit 1
+          fi
+
+          if [[ "${firmware_bins[0]}" != "${expected_path}" ]]; then
+            echo "::error::Firmware binary path mismatch. Expected ${expected_path}, found ${firmware_bins[0]}"
+            exit 1
+          fi
+
+          if [[ ! -s "${expected_path}" ]]; then
+            echo "::error::Firmware artifact exists but is empty: ${expected_path}"
+            exit 1
+          fi
+
+          echo "path=${expected_path}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes from CHANGELOG
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+
+          awk -v target="$version" '
+            index($0, "## [" target "] - ") == 1 { capture=1; next }
+            capture && $0 ~ /^## \[v[0-9]+\.[0-9]+\.[0-9]+\] - / { exit }
+            capture { print }
+          ' CHANGELOG.md > release_notes.md
+
+          if [[ ! -s release_notes.md ]]; then
+            echo "::error::Could not extract release notes for ${version} from CHANGELOG.md"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$version"
+
+          if ! git push origin "refs/tags/${version}"; then
+            echo "::error::Failed to push tag ${version}. It may already exist remotely."
+            exit 1
+          fi
+
+      - name: Create GitHub release and upload firmware
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          firmware_path="${{ steps.firmware.outputs.path }}"
+
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "::error::GitHub CLI (gh) is not installed on runner."
+            exit 1
+          fi
+
+          gh release create "$version" "${firmware_path}#firmware.bin" \
+            --title "$version" \
+            --notes-file release_notes.md \
+            --verify-tag

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ pio device monitor -b 115200
 - `docs/SMOKE_TEST_SPEC.md` for smoke verification details
 
 ## Changelog and releases
-- Update `CHANGELOG.md` in prepend order (newest entry first) for each merged PR.
-- Tag a release that matches the changelog update after merge.
+- Before merging to `main`, prepend a changelog release entry using `## [vX.Y.Z] - YYYY-MM-DD`.
+- After merge, GitHub Actions (`.github/workflows/release.yml`) automatically tags that version, creates a GitHub release, and uploads `firmware.bin` built for `esp32-s3-devkitc-1-n32r16v`.
 
 ## License
 MIT (see `LICENSE`).

--- a/docs/AUTOMATION_POLICY.md
+++ b/docs/AUTOMATION_POLICY.md
@@ -23,4 +23,6 @@ Automation MUST stop and ask for human input when:
 
 ## Release hygiene (required after merge)
 - Every merged PR must update `CHANGELOG.md` (prepend order; newest entry first).
-- After merging, create and push a release tag that matches the changelog entry.
+- After a PR is merged to `main`, `.github/workflows/release.yml` reads the newest changelog release entry (`## [vX.Y.Z] - YYYY-MM-DD`) and uses that version.
+- The release workflow builds `esp32-s3-devkitc-1-n32r16v`, tags the merge commit, creates the GitHub release, and uploads `firmware.bin`.
+- If changelog parsing, tag creation, or firmware artifact checks fail, the release job stops with explicit errors and does not publish a release.


### PR DESCRIPTION
## Linked Issue
Fixes: https://github.com/i-schuyler/esp32-s3-media-player/issues/11

## Scope
- Add post-merge release workflow
- Create tag and GitHub release from newest CHANGELOG version
- Build and upload the correct firmware.bin for esp32-s3-devkitc-1-n32r16v
- Update minimal maintainer docs for the release flow

RISK: med
BREAKING: no
NEEDS_HIL: no
