### PR TITLE
Issue #16: allow manual firmware.bin attach to an existing release tag

### DIFF
--- a/.github/workflows/manual-release-attach.yml
+++ b/.github/workflows/manual-release-attach.yml
@@ -1,0 +1,124 @@
+name: Manual Release Asset Attach
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to attach firmware.bin to (example: v0.1.3)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  attach-firmware:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository with tags
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag input and existing tag/release
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          tag="${{ inputs.tag }}"
+          if [[ -z "$tag" ]]; then
+            echo "::error::Input 'tag' is required. Example: v0.1.3"
+            exit 1
+          fi
+
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid tag format: '$tag'. Expected semantic tag like v0.1.3"
+            exit 1
+          fi
+
+          git fetch --tags --force origin
+
+          if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+            echo "::error::Tag '${tag}' does not exist in this repository."
+            exit 1
+          fi
+
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "::error::GitHub CLI (gh) is not installed on runner."
+            exit 1
+          fi
+
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            echo "::error::GitHub release for tag '${tag}' does not exist. Create the release first."
+            exit 1
+          fi
+
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout requested tag
+        run: |
+          set -euo pipefail
+          git checkout "refs/tags/${{ steps.target.outputs.tag }}"
+
+      - name: Build firmware for esp32-s3-devkitc-1-n32r16v
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --upgrade pip
+          python3 -m pip install --quiet platformio
+          pio run -e esp32-s3-devkitc-1-n32r16v
+
+      - name: Validate firmware artifact
+        id: firmware
+        run: |
+          set -euo pipefail
+
+          expected_path=".pio/build/esp32-s3-devkitc-1-n32r16v/firmware.bin"
+          mapfile -t firmware_bins < <(find .pio/build -type f -name firmware.bin | sort)
+
+          if (( ${#firmware_bins[@]} == 0 )); then
+            echo "::error::No firmware.bin artifact found under .pio/build after build."
+            exit 1
+          fi
+
+          if (( ${#firmware_bins[@]} > 1 )); then
+            echo "::error::Ambiguous firmware artifacts detected. Expected exactly one firmware.bin, found ${#firmware_bins[@]}:"
+            printf ' - %s\n' "${firmware_bins[@]}"
+            exit 1
+          fi
+
+          if [[ "${firmware_bins[0]}" != "${expected_path}" ]]; then
+            echo "::error::Firmware binary path mismatch. Expected ${expected_path}, found ${firmware_bins[0]}"
+            exit 1
+          fi
+
+          if [[ ! -s "${expected_path}" ]]; then
+            echo "::error::Firmware artifact exists but is empty: ${expected_path}"
+            exit 1
+          fi
+
+          echo "path=${expected_path}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload firmware.bin to existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.target.outputs.tag }}"
+          firmware_path="${{ steps.firmware.outputs.path }}"
+
+          if [[ -z "$tag" ]]; then
+            echo "::error::Upload target tag is empty."
+            exit 1
+          fi
+
+          if [[ ! -f "$firmware_path" ]]; then
+            echo "::error::Upload asset does not exist: $firmware_path"
+            exit 1
+          fi
+
+          if ! gh release upload "$tag" "${firmware_path}#firmware.bin" --clobber; then
+            echo "::error::Failed to upload firmware.bin to release '${tag}'."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ pio device monitor -b 115200
 - Follow `docs/RELEASE_AND_PIN_POLICY.md` for version bump and pin/docs alignment guardrails.
 - Before merging to `main`, prepend a changelog release entry using `## [vX.Y.Z] - YYYY-MM-DD`.
 - After merge, GitHub Actions (`.github/workflows/release.yml`) automatically tags that version, creates a GitHub release, and uploads `firmware.bin` built for `esp32-s3-devkitc-1-n32r16v`.
+- If an existing release is missing `firmware.bin`, run `.github/workflows/manual-release-attach.yml` manually with the existing release tag (for example `v0.1.3`).
 
 ## License
 MIT (see `LICENSE`).

--- a/docs/AUTOMATION_POLICY.md
+++ b/docs/AUTOMATION_POLICY.md
@@ -29,3 +29,4 @@ Automation MUST stop and ask for human input when:
 - After a PR is merged to `main`, `.github/workflows/release.yml` reads the newest changelog release entry (`## [vX.Y.Z] - YYYY-MM-DD`) and uses that version.
 - The release workflow builds `esp32-s3-devkitc-1-n32r16v`, tags the merge commit, creates the GitHub release, and uploads `firmware.bin`.
 - If changelog parsing, tag creation, or firmware artifact checks fail, the release job stops with explicit errors and does not publish a release.
+- For an already-existing tag/release missing `firmware.bin`, run `.github/workflows/manual-release-attach.yml` via `workflow_dispatch` and provide the existing tag (for example `v0.1.3`).


### PR DESCRIPTION
## Linked Issue
Fixes: https://github.com/i-schuyler/esp32-s3-media-player/issues/16

## Scope
- Add manual workflow path to build firmware.bin for an existing tag
- Upload firmware.bin to an already-existing GitHub release
- Preserve existing post-merge release automation

RISK: med
BREAKING: no
NEEDS_HIL: no
