### PR TITLE
Issue #37: fix SD bring-up for known-good FAT32 card and correct card_comm_failure path

### DIFF
--- a/docs/ISSUE_37_IMPLEMENTATION_PLAN.md
+++ b/docs/ISSUE_37_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,43 @@
+# Issue #37 Implementation Plan
+
+Issue: https://github.com/i-schuyler/esp32-s3-media-player/issues/37
+
+## Goal
+Fix firmware-side SD SPI bring-up reliability for a known-good FAT32 card on `esp32-s3-devkitc-1-n32r16v`, and make browser-visible SD diagnostics more actionable for true root-cause triage.
+
+## Scope (minimal)
+- Harden SD bring-up with a lightweight SPI preflight response check and bounded retry-at-speed attempts.
+- Ensure SD failure-stage reporting clearly distinguishes:
+  - card absent / no communication
+  - init/select failure
+  - mount/filesystem failure
+  - root-open/read failure
+- Keep OTA, streaming, and non-SD diagnostics behavior unchanged.
+
+## Mapping to ACCEPTANCE.md
+- `ACCEPTANCE.md` #3/#4: SD browser root listing remains the success-path behavior after mount.
+- `ACCEPTANCE.md` #7/#8/#9/#10: existing streaming Range + cache semantics remain unchanged.
+- `ACCEPTANCE.md` #13: CI remains green with policy-compliant PR metadata.
+
+Issue-specific acceptance beyond `ACCEPTANCE.md`:
+- Firmware-side SD bring-up no longer defaults known-good card failures into only `card_comm_failure`; stage detail now differentiates init/select vs mount/filesystem where possible.
+- Browser-visible SD diagnostics stay accurate and actionable without expanding unrelated feature surface.
+
+## Mapping to docs/SMOKE_TEST_SPEC.md
+- Preserve SD mount/read/list serial markers (`SD: MOUNTED`, `SD: READ OK`, `SD: LIST OK`) on success path.
+- Preserve browser diagnostics flow for SD-unavailable state via `/files` and `/sd-diagnostics`.
+- Preserve streaming smoke regression checks (`Range: bytes=0-1023` -> `206` + `Content-Range`).
+
+## Implementation Steps
+1. Add SD SPI CMD0 preflight probe in `src/main.cpp` and use it in mount attempts.
+2. Reclassify SD init failures so stage codes map to the issue-required categories.
+3. Add bounded per-speed retry attempts to improve known-good card bring-up reliability while keeping current pin mapping and target env unchanged.
+4. Validate with `./ci.sh` (policy + compile for `esp32-s3-devkitc-1-n32r16v`).
+
+## Verification
+- CI/build: run `./ci.sh` locally (includes PlatformIO build for `esp32-s3-devkitc-1-n32r16v`).
+- Manual (issue + smoke-spec aligned):
+  - Insert known-good FAT32 card with documented wiring and verify SD no longer reports `card_comm_failure` for firmware-side init-select failures.
+  - Confirm `/files` loads and root listing works on success.
+  - Confirm `/sd-diagnostics` stage/detail/guidance map to observed failure class when inducing faults.
+  - Re-run streaming spot check (`Range: bytes=0-1023`) and OTA page sanity to confirm no regression outside SD scope.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ constexpr uint8_t kSdMosiPin = 10;
 constexpr uint32_t kSdSpiHz = 4000000;
 constexpr uint32_t kSdInitHz = 400000;
 constexpr uint8_t kSdInitClockBytes = 10;
+constexpr uint8_t kSdAttemptsPerSpeed = 2;
 constexpr uint32_t kSdSpiRetryHz[] = {kSdInitHz, 1000000, 2000000, kSdSpiHz};
 constexpr const char* kSdMountPoint = "/sd";
 constexpr const char* kSdFormatConfirmToken = "FORMAT";
@@ -400,6 +401,34 @@ String sdMisoIdleHint() {
   return digitalRead(kSdMisoPin) == LOW ? F("miso_idle=low") : F("miso_idle=high");
 }
 
+bool sdCardRespondsToCmd0() {
+  SPI.beginTransaction(SPISettings(kSdInitHz, MSBFIRST, SPI_MODE0));
+  digitalWrite(kSdCsPin, HIGH);
+  for (uint8_t i = 0; i < kSdInitClockBytes; ++i) {
+    SPI.transfer(0xFF);
+  }
+
+  digitalWrite(kSdCsPin, LOW);
+  SPI.transfer(0xFF);
+  SPI.transfer(0x40);
+  SPI.transfer(0x00);
+  SPI.transfer(0x00);
+  SPI.transfer(0x00);
+  SPI.transfer(0x00);
+  SPI.transfer(0x95);
+
+  uint8_t r1 = 0xFF;
+  for (uint8_t i = 0; i < 10; ++i) {
+    r1 = SPI.transfer(0xFF);
+    if ((r1 & 0x80) == 0) break;
+  }
+
+  digitalWrite(kSdCsPin, HIGH);
+  SPI.transfer(0xFF);
+  SPI.endTransaction();
+  return r1 == 0x01;
+}
+
 void primeSdSpiBus() {
   pinMode(kSdCsPin, OUTPUT);
   pinMode(kSdSckPin, OUTPUT);
@@ -420,14 +449,21 @@ void primeSdSpiBus() {
 
 bool mountSdAttempt(uint32_t hz, bool allowFormat, String& detail, SdFailureStage& stage, bool& capacityKnown) {
   const String misoHint = sdMisoIdleHint();
+  const bool cmd0Response = sdCardRespondsToCmd0();
+
   if (!SD.begin(kSdCsPin, SPI, hz, kSdMountPoint, 5, allowFormat)) {
     const uint8_t cardType = SD.cardType();
-    if (cardType == CARD_NONE) {
+    if (!cmd0Response) {
       stage = SdFailureStage::kCardCommFailure;
-      detail = String(F("card not detected: SD.begin failed at ")) + sdSpiSpeedLabel(hz) + F(" (cardType=none, ") + misoHint + F(")");
-    } else {
+      detail = String(F("no card response (CMD0 timeout); SD.begin failed at ")) + sdSpiSpeedLabel(hz) +
+               F(" (cardType=") + sdCardTypeLabel(cardType) + F(", ") + misoHint + F(")");
+    } else if (cardType == CARD_NONE) {
       stage = SdFailureStage::kInitBusFailure;
-      detail = String(F("SD.begin failed at ")) + sdSpiSpeedLabel(hz) +
+      detail = String(F("card responded but init/select failed at ")) + sdSpiSpeedLabel(hz) +
+               F(" (cardType=none, ") + misoHint + F(")");
+    } else {
+      stage = SdFailureStage::kMountFsFailure;
+      detail = String(F("SD.begin failed after card init at ")) + sdSpiSpeedLabel(hz) +
                F(" after card response (cardType=") + sdCardTypeLabel(cardType) + F(", ") + misoHint + F(")");
     }
     return false;
@@ -435,8 +471,9 @@ bool mountSdAttempt(uint32_t hz, bool allowFormat, String& detail, SdFailureStag
 
   const uint8_t cardType = SD.cardType();
   if (cardType == CARD_NONE) {
-    stage = SdFailureStage::kCardCommFailure;
-    detail = String(F("card not detected after begin at ")) + sdSpiSpeedLabel(hz) + F(" (") + misoHint + F(")");
+    stage = cmd0Response ? SdFailureStage::kInitBusFailure : SdFailureStage::kCardCommFailure;
+    detail = String(F("card not detected after begin at ")) + sdSpiSpeedLabel(hz) +
+             F(" (cmd0=") + (cmd0Response ? F("ok") : F("timeout")) + F(", ") + misoHint + F(")");
     return false;
   }
 
@@ -465,12 +502,15 @@ bool mountSdWithRetries(bool allowFormat, String& detail, SdFailureStage& stage,
   usedHz = kSdSpiHz;
 
   for (const uint32_t hz : kSdSpiRetryHz) {
-    SD.end();
-    SPI.end();
-    primeSdSpiBus();
-    if (mountSdAttempt(hz, allowFormat, detail, stage, capacityKnown)) {
-      usedHz = hz;
-      return true;
+    for (uint8_t attempt = 0; attempt < kSdAttemptsPerSpeed; ++attempt) {
+      SD.end();
+      SPI.end();
+      primeSdSpiBus();
+      if (mountSdAttempt(hz, allowFormat, detail, stage, capacityKnown)) {
+        usedHz = hz;
+        return true;
+      }
+      delay(12);
     }
   }
   return false;


### PR DESCRIPTION
## Linked Issue
Fixes: https://github.com/i-schuyler/esp32-s3-media-player/issues/37

## Scope
- Fix SD bring-up for a known-good FAT32 card with correct documented wiring
- Correct the current card_comm_failure / SD.begin failed / cardType=none path if it is firmware-side
- Preserve OTA, rolling debug log, streaming, and diagnostics behavior outside this SD scope

RISK: med
BREAKING: no
NEEDS_HIL: no
