### PR TITLE
Issue #41: add deeper browser-visible SD init trace with actual pin and SPI speed reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@
 - PR: <url>
 - Issue: <url>
 
+## [v0.1.11] - 2026-04-06
+
+### Added
+
+* Issue #41 implementation plan mapping deeper SD init diagnostics scope to `ACCEPTANCE.md` and `docs/SMOKE_TEST_SPEC.md`.
+* Browser-visible SD diagnostics now include actual SD pin map in use (CS/SCK/MISO/MOSI), every attempted SPI init speed, and bounded attempt-level init trace details.
+
+### Changed
+
+* Existing SD bring-up path now records attempt-level CMD0 outcome and card-init stage progression into the existing rolling debug log for browser-only troubleshooting.
+* `/api/sd/status` and `/sd-diagnostics` now expose deeper SD init visibility while keeping diagnostics bounded/readable.
+
+### Fixed
+
+* Reduced blind spots when SD bring-up fails before mount by surfacing lower-level init progress/failure detail without requiring USB serial logs.
+
+### Notes
+
+* PR:
+* Issue: https://github.com/i-schuyler/esp32-s3-media-player/issues/41
+
 ## [v0.1.10] - 2026-04-06
 
 ### Added

--- a/docs/ISSUE_41_IMPLEMENTATION_PLAN.md
+++ b/docs/ISSUE_41_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,39 @@
+# Issue #41 Implementation Plan
+
+Issue: https://github.com/i-schuyler/esp32-s3-media-player/issues/41
+
+## Goal
+Add deeper browser-visible SD bring-up diagnostics for v0.1 so SD initialization failures can be triaged without USB serial.
+
+## Scope (minimal)
+- Extend existing SD diagnostics in `src/main.cpp` only.
+- Surface actual SD pin map in use (CS/SCK/MISO/MOSI) in browser-visible SD diagnostics.
+- Surface all attempted SPI init speeds used during SD bring-up.
+- Surface bounded attempt-level init trace details (including CMD0 outcome and stage progression).
+- Add a new top changelog entry for this testable diagnostics slice.
+- Do not change OTA flow, streaming behavior, or board/env targeting.
+
+## Mapping to ACCEPTANCE.md
+- `ACCEPTANCE.md` #7/#8/#9/#10: preserve existing streaming range/caching behavior (no streaming path changes).
+- `ACCEPTANCE.md` #13: keep CI/policy gates green with required PR metadata.
+- Issue acceptance #1/#2/#3/#4/#5: implemented via browser-visible pin map + attempted SPI speed list + bounded init trace lines and rolling debug log integration.
+- Issue acceptance #6/#7/#8/#9/#11: scope avoids OTA/stream regressions and retains compile target `esp32-s3-devkitc-1-n32r16v`.
+- Issue acceptance #10: satisfied by new top changelog entry.
+
+## Mapping to docs/SMOKE_TEST_SPEC.md
+- Follow SD diagnostics checks under manual browser diagnostics (`/files`, `/sd-diagnostics`) and verify stage-specific/actionable output.
+- Preserve streaming smoke behavior (`Range: bytes=0-1023` -> 206 + `Content-Range` and `Accept-Ranges: bytes`).
+- Preserve OTA smoke baseline behavior from the OTA manual regression section.
+
+## Implementation Steps
+1. Add bounded SD init trace capture across mount attempts (attempt number, speed, CMD0 result, key stage result).
+2. Record and expose pin map + every attempted SPI init speed in SD status API and SD diagnostics page.
+3. Mirror important new SD init trace lines into rolling debug log output.
+4. Add `v0.1.11` top changelog entry describing this diagnostics slice.
+5. Run `./ci.sh` to ensure policy gates + compile target remain green.
+
+## Verification
+- `./ci.sh` passes locally, including PlatformIO build for `esp32-s3-devkitc-1-n32r16v`.
+- `/api/sd/status` includes `pin_map`, `attempted_spi_speeds`, and bounded `init_trace`.
+- `/sd-diagnostics` visibly shows pin map, attempted speeds, and bounded init trace.
+- Debug log contains SD init trace lines without requiring USB serial.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ constexpr const char* kExpectedBoardTarget = "esp32-s3-devkitc-1-n32r16v";
 constexpr size_t kChunkSize = 2048;
 constexpr size_t kDebugLogCapacity = 120;
 constexpr size_t kDebugLogLineMaxLen = 220;
+constexpr size_t kSdInitTraceMaxLen = 1400;
 constexpr uint8_t kEspImageMagicByte = 0xE9;
 constexpr int32_t kOtaErrorSizeMismatch = 255;
 constexpr int32_t kOtaErrorBadMagic = 254;
@@ -105,6 +106,9 @@ SdFormatStatus gSdFormatStatus;
 String gDebugLog[kDebugLogCapacity];
 size_t gDebugLogNext = 0;
 size_t gDebugLogCount = 0;
+String gSdPinMap;
+String gSdAttemptedSpeeds;
+String gSdInitTrace;
 
 String htmlEscape(const String& in) {
   String out;
@@ -401,6 +405,71 @@ String sdMisoIdleHint() {
   return digitalRead(kSdMisoPin) == LOW ? F("miso_idle=low") : F("miso_idle=high");
 }
 
+String sdPinMapSummary() {
+  String pinMap;
+  pinMap.reserve(64);
+  pinMap += F("CS=IO");
+  pinMap += String(static_cast<unsigned long>(kSdCsPin));
+  pinMap += F(" SCK=IO");
+  pinMap += String(static_cast<unsigned long>(kSdSckPin));
+  pinMap += F(" MISO=IO");
+  pinMap += String(static_cast<unsigned long>(kSdMisoPin));
+  pinMap += F(" MOSI=IO");
+  pinMap += String(static_cast<unsigned long>(kSdMosiPin));
+  return pinMap;
+}
+
+void appendSdInitTraceLine(const String& line) {
+  if (gSdInitTrace.length() >= kSdInitTraceMaxLen) return;
+  if (gSdInitTrace.length() > 0) {
+    if (gSdInitTrace.length() + 1 > kSdInitTraceMaxLen) return;
+    gSdInitTrace += '\n';
+  }
+  const size_t available = kSdInitTraceMaxLen - gSdInitTrace.length();
+  if (line.length() <= available) {
+    gSdInitTrace += line;
+    return;
+  }
+  if (available <= 3) {
+    gSdInitTrace += F("...");
+    return;
+  }
+  gSdInitTrace += line.substring(0, available - 3);
+  gSdInitTrace += F("...");
+}
+
+void resetSdInitTrace(bool allowFormat) {
+  gSdPinMap = sdPinMapSummary();
+  gSdAttemptedSpeeds = "";
+  gSdInitTrace = "";
+  appendSdInitTraceLine(String(F("start allow_format=")) + (allowFormat ? F("true") : F("false")));
+  appendSdInitTraceLine(String(F("pin_map ")) + gSdPinMap);
+}
+
+void recordSdAttemptedSpeed(uint32_t hz) {
+  if (gSdAttemptedSpeeds.length() > 0) gSdAttemptedSpeeds += F(", ");
+  gSdAttemptedSpeeds += sdSpiSpeedLabel(hz);
+}
+
+void appendSdTraceToDebugLog() {
+  if (gSdInitTrace.length() == 0) return;
+  size_t start = 0;
+  while (start <= gSdInitTrace.length()) {
+    const int newline = gSdInitTrace.indexOf('\n', start);
+    String line;
+    if (newline < 0) {
+      line = gSdInitTrace.substring(start);
+      start = gSdInitTrace.length() + 1;
+    } else {
+      line = gSdInitTrace.substring(start, static_cast<size_t>(newline));
+      start = static_cast<size_t>(newline) + 1;
+    }
+    if (line.length() > 0) {
+      serialAndDebugLog(String(F("SD: TRACE ")) + line);
+    }
+  }
+}
+
 bool sdCardRespondsToCmd0() {
   SPI.beginTransaction(SPISettings(kSdInitHz, MSBFIRST, SPI_MODE0));
   digitalWrite(kSdCsPin, HIGH);
@@ -447,22 +516,28 @@ void primeSdSpiBus() {
   SPI.endTransaction();
 }
 
-bool mountSdAttempt(uint32_t hz, bool allowFormat, String& detail, SdFailureStage& stage, bool& capacityKnown) {
+bool mountSdAttempt(uint32_t hz, bool allowFormat, uint8_t attemptNumber, String& detail, SdFailureStage& stage, bool& capacityKnown) {
   const String misoHint = sdMisoIdleHint();
   const bool cmd0Response = sdCardRespondsToCmd0();
+  String prefix = String(F("attempt#")) + String(static_cast<unsigned long>(attemptNumber)) +
+                  F(" speed=") + sdSpiSpeedLabel(hz) + F(" cmd0=") + (cmd0Response ? F("ok") : F("timeout")) +
+                  F(" ") + misoHint;
 
   if (!SD.begin(kSdCsPin, SPI, hz, kSdMountPoint, 5, allowFormat)) {
     const uint8_t cardType = SD.cardType();
     if (!cmd0Response) {
       stage = SdFailureStage::kCardCommFailure;
+      appendSdInitTraceLine(prefix + F(" stage=card_comm_failure sd_begin=failed cardType=") + sdCardTypeLabel(cardType));
       detail = String(F("no card response (CMD0 timeout); SD.begin failed at ")) + sdSpiSpeedLabel(hz) +
                F(" (cardType=") + sdCardTypeLabel(cardType) + F(", ") + misoHint + F(")");
     } else if (cardType == CARD_NONE) {
       stage = SdFailureStage::kInitBusFailure;
+      appendSdInitTraceLine(prefix + F(" stage=init_bus_failure sd_begin=failed cardType=none"));
       detail = String(F("card responded but init/select failed at ")) + sdSpiSpeedLabel(hz) +
                F(" (cardType=none, ") + misoHint + F(")");
     } else {
       stage = SdFailureStage::kMountFsFailure;
+      appendSdInitTraceLine(prefix + F(" stage=mount_fs_failure sd_begin=failed cardType=") + sdCardTypeLabel(cardType));
       detail = String(F("SD.begin failed after card init at ")) + sdSpiSpeedLabel(hz) +
                F(" after card response (cardType=") + sdCardTypeLabel(cardType) + F(", ") + misoHint + F(")");
     }
@@ -472,6 +547,7 @@ bool mountSdAttempt(uint32_t hz, bool allowFormat, String& detail, SdFailureStag
   const uint8_t cardType = SD.cardType();
   if (cardType == CARD_NONE) {
     stage = cmd0Response ? SdFailureStage::kInitBusFailure : SdFailureStage::kCardCommFailure;
+    appendSdInitTraceLine(prefix + F(" stage=post_begin_card_none sd_begin=ok cardType=none"));
     detail = String(F("card not detected after begin at ")) + sdSpiSpeedLabel(hz) +
              F(" (cmd0=") + (cmd0Response ? F("ok") : F("timeout")) + F(", ") + misoHint + F(")");
     return false;
@@ -480,6 +556,7 @@ bool mountSdAttempt(uint32_t hz, bool allowFormat, String& detail, SdFailureStag
   File root = SD.open("/");
   if (!root || !root.isDirectory()) {
     stage = SdFailureStage::kReadRootFailure;
+    appendSdInitTraceLine(prefix + F(" stage=read_root_failure sd_begin=ok cardType=") + sdCardTypeLabel(cardType) + F(" root=open_failed"));
     detail = String(F("root open failed at ")) + sdSpiSpeedLabel(hz);
     return false;
   }
@@ -492,6 +569,8 @@ bool mountSdAttempt(uint32_t hz, bool allowFormat, String& detail, SdFailureStag
     detail += F(" (capacity query unavailable)");
   }
   stage = SdFailureStage::kOk;
+  appendSdInitTraceLine(prefix + F(" stage=ok sd_begin=ok cardType=") + sdCardTypeLabel(cardType) +
+                        F(" root=open_ok capacity_known=") + (capacityKnown ? F("true") : F("false")));
   return true;
 }
 
@@ -500,13 +579,17 @@ bool mountSdWithRetries(bool allowFormat, String& detail, SdFailureStage& stage,
   detail = F("no mount attempts yet");
   capacityKnown = false;
   usedHz = kSdSpiHz;
+  resetSdInitTrace(allowFormat);
+  uint8_t attemptNumber = 0;
 
   for (const uint32_t hz : kSdSpiRetryHz) {
     for (uint8_t attempt = 0; attempt < kSdAttemptsPerSpeed; ++attempt) {
+      ++attemptNumber;
+      recordSdAttemptedSpeed(hz);
       SD.end();
       SPI.end();
       primeSdSpiBus();
-      if (mountSdAttempt(hz, allowFormat, detail, stage, capacityKnown)) {
+      if (mountSdAttempt(hz, allowFormat, attemptNumber, detail, stage, capacityKnown)) {
         usedHz = hz;
         return true;
       }
@@ -724,6 +807,12 @@ void handleSdStatusApi() {
   json += jsonEscape(sdStageGuidance(gSdStatus.stage));
   json += "\",\"detail\":\"";
   json += jsonEscape(gSdStatus.detail);
+  json += "\",\"pin_map\":\"";
+  json += jsonEscape(gSdPinMap);
+  json += "\",\"attempted_spi_speeds\":\"";
+  json += jsonEscape(gSdAttemptedSpeeds);
+  json += "\",\"init_trace\":\"";
+  json += jsonEscape(gSdInitTrace);
   json += "\"}";
   server.send(200, F("application/json"), json);
 }
@@ -744,6 +833,17 @@ void handleSdDiagnosticsPage() {
     body += F("<p><strong>Detail:</strong> ");
     body += htmlEscape(gSdStatus.detail);
     body += F("</p>");
+  }
+  body += F("<p><strong>Pin map in use:</strong> ");
+  body += htmlEscape(gSdPinMap);
+  body += F("</p>");
+  body += F("<p><strong>Attempted SPI init speeds:</strong> ");
+  body += gSdAttemptedSpeeds.length() > 0 ? htmlEscape(gSdAttemptedSpeeds) : F("(none)");
+  body += F("</p>");
+  if (gSdInitTrace.length() > 0) {
+    body += F("<p><strong>Init trace (bounded):</strong></p><pre style='white-space:pre-wrap;background:#111;color:#0f0;padding:12px;border-radius:8px;'>");
+    body += htmlEscape(gSdInitTrace);
+    body += F("</pre>");
   }
   body += F("<p><a href='/debug-log'>Open rolling OTA/SD debug log</a></p>");
   body += F("<p>Serial logs remain available for deeper debugging.</p>");
@@ -1414,12 +1514,18 @@ bool mountSd() {
   if (!mountSdWithRetries(false, detail, stage, capacityKnown, usedHz)) {
     setSdStatus(stage, false, detail);
     serialAndDebugLog(F("SD: MOUNT FAILED"));
+    serialAndDebugLogf("SD: PIN MAP %s", gSdPinMap.c_str());
+    serialAndDebugLogf("SD: ATTEMPTED SPI %s", gSdAttemptedSpeeds.length() > 0 ? gSdAttemptedSpeeds.c_str() : "none");
+    appendSdTraceToDebugLog();
     serialAndDebugLogf("SD: DIAG STAGE=%s", sdStageCode(gSdStatus.stage).c_str());
     serialAndDebugLogf("SD: DETAIL=%s", detail.c_str());
     return false;
   }
 
   serialAndDebugLog(F("SD: MOUNTED"));
+  serialAndDebugLogf("SD: PIN MAP %s", gSdPinMap.c_str());
+  serialAndDebugLogf("SD: ATTEMPTED SPI %s", gSdAttemptedSpeeds.c_str());
+  appendSdTraceToDebugLog();
   if (!capacityKnown) {
     serialAndDebugLog(F("SD: CAPACITY UNKNOWN (continuing because root access works)"));
     setSdStatus(SdFailureStage::kOk, true, detail);


### PR DESCRIPTION
## Linked Issue
Fixes: https://github.com/i-schuyler/esp32-s3-media-player/issues/41

## Scope
- Add deeper browser-visible SD init trace
- Show actual SD pin map and attempted SPI init speeds
- Extend rolling debug log with more useful SD bring-up detail
- Include changelog/version bump for a new testable firmware asset

RISK: med
BREAKING: no
NEEDS_HIL: no
